### PR TITLE
docs: Update MSRV to Rust 1.94.0

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -3,7 +3,7 @@
 ## Getting Started
 
 1. Fork and clone the repo
-2. Install Rust 1.75+: `rustup update stable`
+2. Install Rust 1.94+: `rustup update stable`
 3. Build: `cargo build`
 4. Test: `cargo test --all`
 5. Lint: `cargo clippy --all-targets -- -D warnings && cargo fmt --all -- --check`


### PR DESCRIPTION
## Description
This PR updates the project documentation to reflect the new Minimum Supported Rust Version (MSRV) of 1.94.0. This change is necessary because current transitive dependencies require the  Cargo feature, which is only available in Rust 1.94.0 or newer.

## Changes
- Updated  to specify Rust 1.94+.
- Verified  and  do not explicitly mention MSRV and thus require no changes.

## Testing
- All local checks (build, test, clippy, fmt) passed with Rust 1.94.0 local toolchain.
- Documentation updates are purely textual and do not affect code functionality.

Closes #43