### PR TITLE
feat: Add pre-commit secret scanning, commit-msg CI scan, auto-approve workflow (#45)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,189 @@
+name: Auto-Approve on All Checks Passed
+
+# Triggers when any check suite or workflow run completes on a PR.
+# If ALL required checks have passed, it submits an approving review.
+# This satisfies the "1 required review" branch protection rule,
+# allowing agent-opened PRs to merge without human intervention
+# while still requiring all CI checks to pass.
+
+on:
+  # Fires when a workflow run (check suite) completes
+  check_suite:
+    types: [completed]
+  # Also fires on individual workflow completions for reliability
+  workflow_run:
+    workflows:
+      - "CI"
+      - "Secrets Scan"
+      - "Commit Message Secret Scan"
+      - "PR Hygiene"
+      - "Documentation Check"
+      - "Architectural Code Review"
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  checks: read
+  contents: read
+
+jobs:
+  auto-approve:
+    name: Auto-approve if all checks pass
+    runs-on: ubuntu-latest
+    # Only run for PRs, not pushes
+    if: >-
+      (github.event.check_suite.pull_requests[0] != null) ||
+      (github.event.workflow_run.pull_requests[0] != null)
+    steps:
+      - name: Get PR number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let prNumber;
+
+            if (context.payload.check_suite) {
+              const prs = context.payload.check_suite.pull_requests;
+              if (prs && prs.length > 0) {
+                prNumber = prs[0].number;
+              }
+            } else if (context.payload.workflow_run) {
+              const prs = context.payload.workflow_run.pull_requests;
+              if (prs && prs.length > 0) {
+                prNumber = prs[0].number;
+              }
+            }
+
+            if (!prNumber) {
+              core.info('No PR associated with this event — skipping');
+              return;
+            }
+
+            core.setOutput('number', prNumber);
+            core.info(`PR #${prNumber}`);
+
+      - name: Check all required status checks
+        id: checks
+        if: steps.pr.outputs.number
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.pr.outputs.number }}');
+
+            // Get the PR to find the head SHA
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const headSha = pr.head.sha;
+            core.info(`Head SHA: ${headSha}`);
+
+            // Get all check runs for this commit
+            const { data: checkRuns } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: headSha,
+            });
+
+            // Required checks — these must all pass for auto-approve
+            const requiredChecks = [
+              'Scan commit messages for secrets',
+              'Secrets Scan',
+            ];
+
+            // Check statuses
+            const results = {};
+            for (const run of checkRuns.check_runs) {
+              results[run.name] = {
+                status: run.status,
+                conclusion: run.conclusion,
+              };
+            }
+
+            core.info('Check results:');
+            let allPassed = true;
+            let anyPending = false;
+
+            for (const name of requiredChecks) {
+              const result = results[name];
+              if (!result) {
+                core.info(`  ⏳ ${name}: not started yet`);
+                anyPending = true;
+                allPassed = false;
+              } else if (result.status !== 'completed') {
+                core.info(`  ⏳ ${name}: ${result.status}`);
+                anyPending = true;
+                allPassed = false;
+              } else if (result.conclusion !== 'success') {
+                core.info(`  ❌ ${name}: ${result.conclusion}`);
+                allPassed = false;
+              } else {
+                core.info(`  ✅ ${name}: passed`);
+              }
+            }
+
+            // Also check that NO check has failed
+            for (const run of checkRuns.check_runs) {
+              if (run.status === 'completed' && run.conclusion === 'failure') {
+                core.info(`  ❌ ${run.name}: FAILED`);
+                allPassed = false;
+              }
+            }
+
+            if (anyPending) {
+              core.info('Some checks still pending — skipping auto-approve');
+              core.setOutput('approve', 'false');
+            } else if (allPassed) {
+              core.info('All checks passed!');
+              core.setOutput('approve', 'true');
+            } else {
+              core.info('Some checks failed — not approving');
+              core.setOutput('approve', 'false');
+            }
+
+      - name: Check for existing approval
+        id: existing
+        if: steps.checks.outputs.approve == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.pr.outputs.number }}');
+
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const botApproval = reviews.find(r =>
+              r.user.login === 'github-actions[bot]' &&
+              r.state === 'APPROVED'
+            );
+
+            if (botApproval) {
+              core.info('Already approved by github-actions[bot] — skipping');
+              core.setOutput('already_approved', 'true');
+            } else {
+              core.setOutput('already_approved', 'false');
+            }
+
+      - name: Submit approving review
+        if: >-
+          steps.checks.outputs.approve == 'true' &&
+          steps.existing.outputs.already_approved == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.pr.outputs.number }}');
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              event: 'APPROVE',
+              body: '✅ **Auto-approved** — all CI checks passed.\n\n*Automated review by github-actions[bot]*',
+            });
+
+            core.info(`Approved PR #${prNumber}`);

--- a/.github/workflows/commit-msg-scan.yml
+++ b/.github/workflows/commit-msg-scan.yml
@@ -1,0 +1,123 @@
+name: Commit Message Secret Scan
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  scan-commit-messages:
+    name: Scan commit messages for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan all PR commit messages
+        id: scan
+        run: |
+          echo "Scanning commit messages in PR..."
+          echo ""
+
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          # Secret patterns (same as scripts/check-commit-msg.sh)
+          PATTERNS='(ghp_[a-zA-Z0-9]{36}|gho_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|sk-or-v1-[a-f0-9]{64}|sk-ant-[a-zA-Z0-9]{20,}|sk-proj-[a-zA-Z0-9]{20,}|sk-[a-zA-Z0-9]{48}|AKIA[0-9A-Z]{16}|glpat-[a-zA-Z0-9\-]{20,}|xoxb-[0-9]{10,}|xoxp-[0-9]{10,})'
+
+          # Env dump patterns (searched separately to avoid false positives in diff content)
+          ENV_PATTERNS='^(GH_TOKEN|OPENROUTER_API_KEY|NEO4J_PASSWORD|AWS_SECRET_ACCESS_KEY|GITHUB_TOKEN)=.+'
+
+          FOUND=0
+          REPORT=""
+
+          for SHA in $(git rev-list "$BASE_SHA".."$HEAD_SHA"); do
+            MSG=$(git log --format="%B" -1 "$SHA")
+            SHORT=$(git log --format="%h %s" -1 "$SHA")
+
+            # Check for secret tokens
+            TOKEN_MATCH=$(echo "$MSG" | grep -E "$PATTERNS" || true)
+            # Check for env dump lines
+            ENV_MATCH=$(echo "$MSG" | grep -E "$ENV_PATTERNS" || true)
+
+            if [ -n "$TOKEN_MATCH" ] || [ -n "$ENV_MATCH" ]; then
+              FOUND=$((FOUND + 1))
+              REPORT+="### ❌ \`$SHORT\`\n"
+              if [ -n "$TOKEN_MATCH" ]; then
+                REPORT+="Secret token pattern detected:\n\`\`\`\n$TOKEN_MATCH\n\`\`\`\n"
+              fi
+              if [ -n "$ENV_MATCH" ]; then
+                REPORT+="Environment variable dump detected:\n\`\`\`\n$ENV_MATCH\n\`\`\`\n"
+              fi
+              REPORT+="\n"
+            else
+              echo "✅ $SHORT"
+            fi
+          done
+
+          if [ "$FOUND" -gt 0 ]; then
+            echo "found=$FOUND" >> "$GITHUB_OUTPUT"
+            # Write report to file for the comment step
+            echo -e "$REPORT" > /tmp/scan-report.md
+            echo ""
+            echo "🚨 Found secrets in $FOUND commit message(s)"
+            exit 1
+          else
+            echo ""
+            echo "✅ All commit messages are clean"
+          fi
+
+      - name: Comment on PR if secrets found
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.existsSync('/tmp/scan-report.md')
+              ? fs.readFileSync('/tmp/scan-report.md', 'utf8')
+              : 'Secret patterns detected in commit messages.';
+
+            const body = `## 🚨 Secrets Detected in Commit Messages
+
+            This PR contains commit messages with potential secrets or environment variable dumps.
+
+            ${report}
+
+            **This must be fixed before merge.** You need to rewrite the commit messages:
+
+            1. \`git rebase -i <base-commit>\` and edit the offending commits
+            2. Remove the secrets from the commit messages
+            3. Force-push the branch
+
+            *🔒 Automated commit-message secret scan*`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c =>
+              c.body && c.body.includes('Secrets Detected in Commit Messages')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# Pre-commit hooks for pi-daemon
+# Install: pip install pre-commit && pre-commit install --hook-type pre-commit --hook-type commit-msg
+# Docs: https://pre-commit.com/
+
+repos:
+  # Gitleaks — scan staged file content for secrets
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
+  # Custom commit-msg hook — scan commit messages for leaked secrets
+  - repo: local
+    hooks:
+      - id: check-commit-msg-secrets
+        name: Check commit message for secrets
+        entry: scripts/check-commit-msg.sh
+        language: script
+        stages: [commit-msg]
+        always_run: true

--- a/docs/PR-Reviews.md
+++ b/docs/PR-Reviews.md
@@ -19,6 +19,7 @@ Checks fall into two categories:
 |-------|------|:--------:|:-------:|-------------|
 | **Secrets Scan** | TruffleHog | ✅ | ✅ | Scans full diff for leaked API keys, tokens, passwords, private keys. AI agents are prone to committing secrets from context. |
 | **Hardcoded Credentials** | gitleaks / custom grep | ✅ | ✅ | Regex patterns for `sk-ant-`, `ghp_`, `Bearer `, `password = "`, etc. Catches unverified patterns TruffleHog might miss. |
+| **Commit Message Secrets** | Custom script | ✅ | ✅ | Scans all PR commit messages for secret patterns and env dumps. AI agents are prone to dumping `env` output into commit messages. See `commit-msg-scan.yml`. |
 | **SSRF / Private IP** | Custom grep | ⚠️ | ❌ | Scans for hardcoded private IPs, cloud metadata URLs, or localhost in non-test code. Advisory only — some localhost refs are intentional. |
 
 ### 📦 Supply Chain & Dependencies
@@ -158,6 +159,39 @@ The most unique check. Uses **Gemini 2.5 Flash** via OpenRouter to review every 
 **Output:** Comment with per-check pass/fail/skip table + issues list + native GitHub Check (pass/fail).
 
 **Cost:** ~$0.01–0.05 per PR review (Gemini 2.5 Flash pricing).
+
+---
+
+## Branch Protection & Auto-Approve
+
+The `main` branch is protected with the following rules:
+
+- **Require a pull request** — no direct pushes to `main`
+- **Require 1 approving review** — satisfied by the auto-approve bot (see below)
+- **Require status checks to pass** — security scans and commit-message scan must pass
+- **No force-push** — prevents history rewriting on `main`
+- **No deletions** — prevents accidental branch deletion
+
+### Auto-Approve Workflow
+
+The `auto-approve.yml` workflow acts as the required reviewer. When all CI checks on a PR complete successfully, it automatically submits an approving review as `github-actions[bot]`. This allows agent-opened PRs to merge without human intervention while still enforcing that every check passes.
+
+If any check fails, the bot does not approve and the PR cannot be merged.
+
+### Pre-commit Hooks
+
+Local secret scanning is available via [pre-commit](https://pre-commit.com/):
+
+```bash
+pip install pre-commit
+pre-commit install --hook-type pre-commit --hook-type commit-msg
+```
+
+This installs:
+- **gitleaks** — scans staged file content for secrets
+- **check-commit-msg.sh** — scans commit messages for secret patterns and env dumps
+
+Agents can bypass with `--no-verify`, which is why CI scanning is the real backstop.
 
 ---
 

--- a/scripts/check-commit-msg.sh
+++ b/scripts/check-commit-msg.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# ============================================================
+# check-commit-msg.sh — Pre-commit hook (commit-msg stage)
+#
+# Scans the commit message for leaked secrets, API keys, tokens,
+# passwords, and env dump patterns. Blocks the commit if found.
+#
+# Used by: .pre-commit-config.yaml (commit-msg stage)
+# Usage:   scripts/check-commit-msg.sh <commit-msg-file>
+# ============================================================
+set -euo pipefail
+
+MSG_FILE="${1:?Usage: check-commit-msg.sh <commit-msg-file>}"
+
+if [ ! -f "$MSG_FILE" ]; then
+  echo "Error: commit message file not found: $MSG_FILE"
+  exit 1
+fi
+
+# ── Secret patterns ──────────────────────────────────────────
+# Each pattern is a grep -E regex. Add new patterns here.
+PATTERNS=(
+  # GitHub tokens
+  'ghp_[a-zA-Z0-9]{36}'
+  'gho_[a-zA-Z0-9]{36}'
+  'github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}'
+  # OpenRouter / OpenAI
+  'sk-or-v1-[a-f0-9]{64}'
+  'sk-ant-[a-zA-Z0-9]{20,}'
+  'sk-proj-[a-zA-Z0-9]{20,}'
+  'sk-[a-zA-Z0-9]{48}'
+  # AWS
+  'AKIA[0-9A-Z]{16}'
+  # GitLab
+  'glpat-[a-zA-Z0-9\-]{20,}'
+  # Slack
+  'xoxb-[0-9]{10,}'
+  'xoxp-[0-9]{10,}'
+  # Generic env dump indicators (KEY=value on its own line)
+  '^(GH_TOKEN|OPENROUTER_API_KEY|NEO4J_PASSWORD|AWS_SECRET_ACCESS_KEY|GITHUB_TOKEN)=.+'
+  # Inline password assignments
+  'password\s*=\s*["\x27][^"\x27]{4,}'
+)
+
+COMBINED_PATTERN=$(IFS='|'; echo "${PATTERNS[*]}")
+
+# ── Scan ─────────────────────────────────────────────────────
+MATCHES=$(grep -nE "$COMBINED_PATTERN" "$MSG_FILE" 2>/dev/null || true)
+
+if [ -n "$MATCHES" ]; then
+  echo ""
+  echo "🚨 COMMIT BLOCKED — Potential secrets detected in commit message!"
+  echo ""
+  echo "Matches found:"
+  echo "$MATCHES" | while IFS= read -r line; do
+    echo "  ⚠️  $line"
+  done
+  echo ""
+  echo "If these are false positives (e.g., documentation about secret patterns),"
+  echo "you can bypass with: git commit --no-verify"
+  echo ""
+  echo "Otherwise, edit your commit message to remove the secrets."
+  echo ""
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Implements multi-layer secret scanning and branch protection infrastructure to prevent future credential leaks in commits.

### Background

A recent commit by an AI agent (Gemini Flash 2.5) dumped the full container `env` output into a commit message, exposing `GH_TOKEN`, `OPENROUTER_API_KEY`, and `NEO4J_PASSWORD`. Existing CI scanners (TruffleHog) only scanned file diffs, not commit messages.

### Changes

**Pre-commit hooks (`.pre-commit-config.yaml`)**
- gitleaks hook for staged file content scanning
- Custom `commit-msg` hook (`scripts/check-commit-msg.sh`) that regex-scans commit messages for secret patterns: `ghp_`, `sk-or-v1`, `sk-ant`, `AKIA`, env dump lines, password assignments

**CI commit-message scan (`commit-msg-scan.yml`)**
- Iterates all commits in a PR, scans messages for secret patterns
- Posts a detailed comment if secrets found, blocks merge
- Backstop for agents that bypass local hooks with `--no-verify`

**Auto-approve workflow (`auto-approve.yml`)**
- Triggers when all check suites complete on a PR
- Verifies every required check passed, then submits an approving review as `github-actions[bot]`
- Satisfies the 1-review branch protection requirement, allowing agent-opened PRs to self-merge while enforcing all CI checks

**Documentation**
- Added commit-message scan to Security & Secrets table in PR-Reviews.md
- Added Branch Protection & Auto-Approve section with pre-commit setup instructions

### Branch protection rules (to be applied after merge)
- Require PR for merges (no direct push to `main`)
- Require 1 approving review (satisfied by auto-approve bot)
- Require status checks to pass
- No force-push / deletion of `main`

Closes #45