### PR TITLE
fix: override LLM verdict when structured checks contain failures (#52)

### DIFF
--- a/.github/workflows/arch-review.yml
+++ b/.github/workflows/arch-review.yml
@@ -223,7 +223,13 @@ jobs:
               };
             }
 
-            const verdict = review.verdict || 'PASS';
+            // Don't trust the LLM's verdict — compute it from structured output.
+            // If any check has status "fail", the verdict is FAIL regardless of
+            // what the LLM decided. This prevents the model from passing a review
+            // that contains ❌ failures (see #52).
+            const hasFailedCheck = (review.checks || []).some(c => c.status === 'fail');
+            const hasErrorIssue = (review.issues || []).some(i => i.severity === 'error');
+            const verdict = (hasFailedCheck || hasErrorIssue) ? 'FAIL' : (review.verdict || 'PASS');
             const conclusion = verdict === 'PASS' ? 'success' : 'failure';
 
             // Build check run summary


### PR DESCRIPTION
## Summary

The architectural review was passing overall despite finding ❌ failures in individual checks. This PR fixes the verdict logic so that any failed check forces a FAIL.

## Problem

The LLM (Gemini 2.5 Flash) was making the pass/fail decision based on its own severity judgment. When it found a Documentation ❌ failure, it still returned `verdict: PASS` because it considered the issue "not severe enough." This defeats the purpose of having structured checks.

## Fix

One targeted change in `arch-review.yml`: after parsing the LLM's JSON output, **override the verdict** by scanning the structured data ourselves:

```javascript
const hasFailedCheck = (review.checks || []).some(c => c.status === 'fail');
const hasErrorIssue = (review.issues || []).some(i => i.severity === 'error');
const verdict = (hasFailedCheck || hasErrorIssue) ? 'FAIL' : (review.verdict || 'PASS');
```

The LLM still provides analysis, but it no longer makes the final pass/fail call.

## Changes

- `.github/workflows/arch-review.yml`: 7 lines added, 1 removed

## Testing

- YAML validates correctly
- Logic is straightforward: if any check is `fail` or any issue is `error`, verdict is FAIL
- No Rust code changes

Closes #52