### PR TITLE
fix: add workflow_dispatch manual trigger to auto-approve (#60)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -11,6 +11,14 @@ name: Auto-Approve on All Checks Passed
 # effect until the PR is merged. This is a GitHub Actions limitation.
 
 on:
+  # Manual trigger — escape hatch when event-driven triggers miss a PR.
+  # Usage: gh workflow run auto-approve.yml -f pr_number=59
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to auto-approve (checks must still pass)'
+        required: true
+        type: number
   # Fires when a workflow run (check suite) completes
   check_suite:
     types: [completed]
@@ -34,8 +42,9 @@ jobs:
   auto-approve:
     name: Auto-approve if all checks pass
     runs-on: ubuntu-latest
-    # Only run for PRs, not pushes
+    # Only run for PRs (or manual dispatch with a pr_number)
     if: >-
+      (github.event_name == 'workflow_dispatch') ||
       (github.event.check_suite.pull_requests[0] != null) ||
       (github.event.workflow_run.pull_requests[0] != null)
     steps:
@@ -46,7 +55,12 @@ jobs:
           script: |
             let prNumber;
 
-            if (context.payload.check_suite) {
+            // Manual dispatch — pr_number provided as input
+            const inputPR = '${{ github.event.inputs.pr_number }}';
+            if (inputPR && inputPR !== '') {
+              prNumber = parseInt(inputPR);
+              core.info(`Manual dispatch for PR #${prNumber}`);
+            } else if (context.payload.check_suite) {
               const prs = context.payload.check_suite.pull_requests;
               if (prs && prs.length > 0) {
                 prNumber = prs[0].number;


### PR DESCRIPTION
## Fixes #60 (partial — manual trigger escape hatch)

Adds a `workflow_dispatch` trigger to the auto-approve workflow so it can be manually re-fired when event-driven triggers fail due to race conditions or Checks API gaps.

### Problem

When auto-approve gets stuck (as on PR #59 where `Secrets Scan` and `Credential Patterns` never appeared in the Checks API), there's no way to retry without pushing an empty commit and burning through all 32 CI checks again.

### Solution

```bash
# Manual re-trigger — checks must still pass, this is NOT a bypass
gh workflow run auto-approve.yml -f pr_number=59
```

### Changes

- **`workflow_dispatch` trigger** with `pr_number` input (required)
- **Updated job condition** to allow manual dispatch alongside existing `check_suite`/`workflow_run` triggers  
- **PR number detection** prioritizes `inputs.pr_number` from manual dispatch, falls back to event payloads
- **All check validation still applies** — this is an escape hatch, not a bypass. The hardcoded check list still runs (the dynamic discovery fix is tracked separately in #60)

### Testing

After merge, verify with:
```bash
gh workflow run auto-approve.yml -f pr_number=59
```

The workflow should pick up PR #59, evaluate all checks, and approve if they've all passed.

### Note

This is a targeted fix for the "no manual re-trigger" gap (item 6 in #60). The larger dynamic check discovery redesign (items 1–5) is tracked separately in the same issue.