### PR TITLE
fix: paginate checks API to find all check runs (#60)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -98,24 +98,24 @@ jobs:
             const headSha = pr.head.sha;
             core.info(`Head SHA: ${headSha}`);
 
-            // Get all check runs for this commit
-            const { data: checkRuns } = await github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: headSha,
-            });
+            // Get all check runs for this commit (paginated — default per_page
+            // is 30, which silently drops checks when there are 30+).
+            const allCheckRuns = await github.paginate(
+              github.rest.checks.listForRef,
+              { owner: context.repo.owner, repo: context.repo.repo, ref: headSha, per_page: 100 },
+              (response) => response.data.check_runs
+            );
+            const checkRuns = { check_runs: allCheckRuns };
+            core.info(`Found ${allCheckRuns.length} check runs (paginated)`);
 
             // Required checks — these must all pass for auto-approve.
             // This list includes ALL blocking checks so we never
             // approve before any job finishes. Updated to match actual CI output.
             const requiredChecks = [
               // Security workflows
-              // NOTE: 'Secrets Scan' and 'Credential Patterns' are intentionally
-              // excluded — GitHub's Checks API (checks.listForRef) never returns
-              // them for the PR head SHA, causing permanent "not started yet" state.
-              // They are still caught by the fail-safe sweep below that rejects
-              // approval if ANY check run has conclusion === 'failure'.
               'Scan commit messages for secrets',
+              'Secrets Scan',
+              'Credential Patterns',
               // Core CI jobs
               'Lint',
               'Security Audit',


### PR DESCRIPTION
## Fixes the root cause of #60

### The real problem

The `checks.listForRef` REST API defaults to `per_page=30`. This repo has 32 checks. The auto-approve workflow never paginated, so **2 random checks were silently dropped on every single API call**. This was the root cause of the entire ghost checks saga — not a GitHub bug, just missing pagination.

```bash
# Before (30 of 32)
gh api repos/.../commits/{sha}/check-runs
→ total_count: 32, returned: 30

# After (all 32)
gh api "repos/.../commits/{sha}/check-runs?per_page=100"
→ total_count: 32, returned: 32
```

### Fix

Replace the single unpaginated API call with `github.paginate()`, which follows all `Link: rel="next"` headers automatically:

```javascript
const allCheckRuns = await github.paginate(
  github.rest.checks.listForRef,
  { owner, repo, ref: headSha, per_page: 100 },
  (response) => response.data.check_runs
);
```

This handles any number of checks — even if the repo grows past 100.

### Also

Restores `Secrets Scan` and `Credential Patterns` to the required checks list. They were removed in #62 as a workaround for this pagination bug — no longer needed now that we fetch all pages.

### Impact

- Every check is now visible to auto-approve, regardless of count
- No more "not started yet" ghosts
- The #62 workaround is reverted cleanly