### PR TITLE
feat: Kernel — agent registry + event bus (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Core types crate (`pi-daemon-types`) with agent, message, event, and error types (#4)
+- Kernel crate (`pi-daemon-kernel`) with agent registry and event bus (#5)
 - Comprehensive CI/CD pipeline with 25+ automated checks (#24)
 - Supply chain security checks with cargo-deny (#34)
 - Code quality checks: unsafe detection, TODO tracking, docs drift, binary size (#35)

--- a/crates/pi-daemon-kernel/src/event_bus.rs
+++ b/crates/pi-daemon-kernel/src/event_bus.rs
@@ -1,0 +1,292 @@
+use dashmap::DashMap;
+use pi_daemon_types::agent::AgentId;
+use pi_daemon_types::event::{Event, EventTarget};
+use std::collections::VecDeque;
+use std::sync::Arc;
+use tokio::sync::{broadcast, RwLock};
+use tracing::debug;
+
+/// Maximum events retained in the history ring buffer.
+const HISTORY_SIZE: usize = 1000;
+
+/// Broadcast channel capacity.
+const CHANNEL_CAPACITY: usize = 1024;
+
+/// Central event bus for all inter-agent and system communication.
+pub struct EventBus {
+    /// Global broadcast channel.
+    sender: broadcast::Sender<Event>,
+    /// Per-agent channels for targeted events.
+    agent_channels: DashMap<AgentId, broadcast::Sender<Event>>,
+    /// Event history ring buffer (most recent HISTORY_SIZE events).
+    history: Arc<RwLock<VecDeque<Event>>>,
+}
+
+impl EventBus {
+    pub fn new() -> Self {
+        let (sender, _) = broadcast::channel(CHANNEL_CAPACITY);
+        Self {
+            sender,
+            agent_channels: DashMap::new(),
+            history: Arc::new(RwLock::new(VecDeque::with_capacity(HISTORY_SIZE))),
+        }
+    }
+
+    /// Publish an event. Routes to specific agent or broadcasts to all.
+    pub async fn publish(&self, event: Event) {
+        debug!(event_id = %event.id, source = %event.source, "Publishing event");
+
+        // Store in history ring buffer
+        {
+            let mut history = self.history.write().await;
+            if history.len() >= HISTORY_SIZE {
+                history.pop_front();
+            }
+            history.push_back(event.clone());
+        }
+
+        // Route to target
+        match &event.target {
+            EventTarget::Agent(agent_id) => {
+                if let Some(sender) = self.agent_channels.get(agent_id) {
+                    let _ = sender.send(event);
+                }
+            }
+            EventTarget::Broadcast => {
+                let _ = self.sender.send(event);
+            }
+        }
+    }
+
+    /// Subscribe to the global broadcast channel.
+    pub fn subscribe_global(&self) -> broadcast::Receiver<Event> {
+        self.sender.subscribe()
+    }
+
+    /// Subscribe to events for a specific agent.
+    /// Creates the per-agent channel if it doesn't exist.
+    pub fn subscribe_agent(&self, agent_id: &AgentId) -> broadcast::Receiver<Event> {
+        self.agent_channels
+            .entry(agent_id.clone())
+            .or_insert_with(|| broadcast::channel(CHANNEL_CAPACITY).0)
+            .subscribe()
+    }
+
+    /// Remove per-agent channel (call when agent unregisters).
+    pub fn remove_agent_channel(&self, agent_id: &AgentId) {
+        self.agent_channels.remove(agent_id);
+    }
+
+    /// Get recent event history.
+    pub async fn history(&self, limit: usize) -> Vec<Event> {
+        let history = self.history.read().await;
+        history.iter().rev().take(limit).cloned().collect()
+    }
+
+    /// Check if an agent channel exists (for testing).
+    pub fn has_agent_channel(&self, agent_id: &AgentId) -> bool {
+        self.agent_channels.contains_key(agent_id)
+    }
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pi_daemon_types::event::{EventPayload, EventTarget};
+    use tokio::time::{timeout, Duration};
+
+    #[tokio::test]
+    async fn test_publish_broadcast_event_subscriber_receives() {
+        let bus = EventBus::new();
+        let mut receiver = bus.subscribe_global();
+
+        let agent_id = AgentId::new();
+        let event = Event::new(
+            agent_id.clone(),
+            EventTarget::Broadcast,
+            EventPayload::System {
+                message: "test".to_string(),
+            },
+        );
+
+        bus.publish(event.clone()).await;
+
+        let received = timeout(Duration::from_millis(100), receiver.recv())
+            .await
+            .expect("Should receive within timeout")
+            .expect("Should receive event");
+
+        assert_eq!(received.id, event.id);
+        assert_eq!(received.source, event.source);
+    }
+
+    #[tokio::test]
+    async fn test_publish_targeted_event_only_target_receives() {
+        let bus = EventBus::new();
+
+        let target_agent = AgentId::new();
+        let other_agent = AgentId::new();
+
+        let mut target_receiver = bus.subscribe_agent(&target_agent);
+        let mut other_receiver = bus.subscribe_agent(&other_agent);
+        let mut global_receiver = bus.subscribe_global();
+
+        let event = Event::new(
+            AgentId::new(),
+            EventTarget::Agent(target_agent.clone()),
+            EventPayload::UserMessage {
+                content: "hello".to_string(),
+            },
+        );
+
+        bus.publish(event.clone()).await;
+
+        // Target agent should receive
+        let received = timeout(Duration::from_millis(100), target_receiver.recv())
+            .await
+            .expect("Target should receive within timeout")
+            .expect("Target should receive event");
+        assert_eq!(received.id, event.id);
+
+        // Other agent should not receive (timeout)
+        let other_result = timeout(Duration::from_millis(50), other_receiver.recv()).await;
+        assert!(
+            other_result.is_err(),
+            "Other agent should not receive targeted event"
+        );
+
+        // Global should not receive (timeout)
+        let global_result = timeout(Duration::from_millis(50), global_receiver.recv()).await;
+        assert!(
+            global_result.is_err(),
+            "Global should not receive targeted event"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_history_stores_events_up_to_limit() {
+        let bus = EventBus::new();
+        let agent_id = AgentId::new();
+
+        // Publish events up to the limit
+        for i in 0..5 {
+            let event = Event::new(
+                agent_id.clone(),
+                EventTarget::Broadcast,
+                EventPayload::System {
+                    message: format!("event {}", i),
+                },
+            );
+            bus.publish(event).await;
+        }
+
+        let history = bus.history(10).await;
+        assert_eq!(history.len(), 5);
+
+        // Events should be in reverse order (newest first)
+        if let EventPayload::System { message } = &history[0].payload {
+            assert_eq!(message, "event 4");
+        } else {
+            panic!("Expected System event");
+        }
+
+        if let EventPayload::System { message } = &history[4].payload {
+            assert_eq!(message, "event 0");
+        } else {
+            panic!("Expected System event");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_history_evicts_oldest_when_full() {
+        let bus = EventBus::new();
+        let agent_id = AgentId::new();
+
+        // Fill beyond HISTORY_SIZE (using small test size)
+        // We'll test with more than HISTORY_SIZE events
+        let test_events = HISTORY_SIZE + 10;
+
+        for i in 0..test_events {
+            let event = Event::new(
+                agent_id.clone(),
+                EventTarget::Broadcast,
+                EventPayload::System {
+                    message: format!("event {}", i),
+                },
+            );
+            bus.publish(event).await;
+        }
+
+        let history = bus.history(HISTORY_SIZE + 20).await;
+
+        // Should only have HISTORY_SIZE events
+        assert_eq!(history.len(), HISTORY_SIZE);
+
+        // Newest event should be the last one we sent
+        if let EventPayload::System { message } = &history[0].payload {
+            assert_eq!(message, &format!("event {}", test_events - 1));
+        } else {
+            panic!("Expected System event");
+        }
+
+        // Oldest event should be the (total - HISTORY_SIZE)th event
+        if let EventPayload::System { message } = &history[HISTORY_SIZE - 1].payload {
+            assert_eq!(message, &format!("event {}", test_events - HISTORY_SIZE));
+        } else {
+            panic!("Expected System event");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_remove_agent_channel() {
+        let bus = EventBus::new();
+        let agent_id = AgentId::new();
+
+        // Create a subscription (which creates the channel)
+        let _receiver = bus.subscribe_agent(&agent_id);
+
+        // Verify channel exists
+        assert!(bus.has_agent_channel(&agent_id));
+
+        // Remove it
+        bus.remove_agent_channel(&agent_id);
+
+        // Verify it's gone
+        assert!(!bus.has_agent_channel(&agent_id));
+    }
+
+    #[tokio::test]
+    async fn test_history_limit() {
+        let bus = EventBus::new();
+        let agent_id = AgentId::new();
+
+        // Publish 10 events
+        for i in 0..10 {
+            let event = Event::new(
+                agent_id.clone(),
+                EventTarget::Broadcast,
+                EventPayload::System {
+                    message: format!("event {}", i),
+                },
+            );
+            bus.publish(event).await;
+        }
+
+        // Request only 3 events
+        let history = bus.history(3).await;
+        assert_eq!(history.len(), 3);
+
+        // Should get the 3 most recent
+        if let EventPayload::System { message } = &history[0].payload {
+            assert_eq!(message, "event 9");
+        } else {
+            panic!("Expected System event");
+        }
+    }
+}

--- a/crates/pi-daemon-kernel/src/kernel.rs
+++ b/crates/pi-daemon-kernel/src/kernel.rs
@@ -1,0 +1,222 @@
+use crate::event_bus::EventBus;
+use crate::registry::AgentRegistry;
+use pi_daemon_types::agent::{AgentId, AgentKind};
+use pi_daemon_types::event::{Event, EventPayload, EventTarget};
+
+/// System agent ID — used as the source for system-level events.
+fn system_agent_id() -> AgentId {
+    AgentId(uuid::Uuid::nil())
+}
+
+/// The main pi-daemon kernel — coordinates all subsystems.
+pub struct PiDaemonKernel {
+    /// Agent registry.
+    pub registry: AgentRegistry,
+    /// Event bus.
+    pub event_bus: EventBus,
+    /// Kernel start time.
+    pub started_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl PiDaemonKernel {
+    /// Create a new kernel.
+    pub fn new() -> Self {
+        // Async initialization will be done in init()
+        Self {
+            registry: AgentRegistry::new(),
+            event_bus: EventBus::new(),
+            started_at: chrono::Utc::now(),
+        }
+    }
+
+    /// Async initialization — publish startup event.
+    pub async fn init(&self) {
+        self.event_bus
+            .publish(Event::new(
+                system_agent_id(),
+                EventTarget::Broadcast,
+                EventPayload::System {
+                    message: "Kernel started".to_string(),
+                },
+            ))
+            .await;
+    }
+
+    /// Register an agent and publish event.
+    pub async fn register_agent(
+        &self,
+        name: String,
+        kind: AgentKind,
+        model: Option<String>,
+    ) -> AgentId {
+        let id = self.registry.register(name.clone(), kind, model);
+        self.event_bus
+            .publish(Event::new(
+                id.clone(),
+                EventTarget::Broadcast,
+                EventPayload::AgentRegistered { name },
+            ))
+            .await;
+        id
+    }
+
+    /// Unregister an agent and publish event.
+    pub async fn unregister_agent(&self, id: &AgentId, reason: String) {
+        let _ = self.registry.unregister(id);
+        self.event_bus.remove_agent_channel(id);
+        self.event_bus
+            .publish(Event::new(
+                id.clone(),
+                EventTarget::Broadcast,
+                EventPayload::AgentDisconnected { reason },
+            ))
+            .await;
+    }
+
+    /// Get uptime in seconds.
+    pub fn uptime_secs(&self) -> i64 {
+        (chrono::Utc::now() - self.started_at).num_seconds()
+    }
+}
+
+impl Default for PiDaemonKernel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pi_daemon_types::agent::AgentKind;
+    use pi_daemon_types::event::EventPayload;
+    use tokio::time::{timeout, Duration};
+
+    #[tokio::test]
+    async fn test_register_agent_returns_valid_id_and_appears_in_registry() {
+        let kernel = PiDaemonKernel::new();
+
+        let id = kernel
+            .register_agent(
+                "test-agent".to_string(),
+                AgentKind::WebChat,
+                Some("claude-sonnet-4".to_string()),
+            )
+            .await;
+
+        // Verify agent is in registry
+        let agent = kernel.registry.get(&id);
+        assert!(agent.is_some());
+
+        let agent = agent.unwrap();
+        assert_eq!(agent.id, id);
+        assert_eq!(agent.name, "test-agent");
+        assert_eq!(agent.kind, AgentKind::WebChat);
+        assert_eq!(agent.model, Some("claude-sonnet-4".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_register_agent_publishes_event() {
+        let kernel = PiDaemonKernel::new();
+        let mut receiver = kernel.event_bus.subscribe_global();
+
+        let id = kernel
+            .register_agent("test-agent".to_string(), AgentKind::PiInstance, None)
+            .await;
+
+        // Should receive registration event
+        let event = timeout(Duration::from_millis(100), receiver.recv())
+            .await
+            .expect("Should receive event within timeout")
+            .expect("Should receive event");
+
+        assert_eq!(event.source, id);
+        if let EventPayload::AgentRegistered { name } = event.payload {
+            assert_eq!(name, "test-agent");
+        } else {
+            panic!("Expected AgentRegistered event");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_unregister_agent_removes_from_registry_and_cleans_up() {
+        let kernel = PiDaemonKernel::new();
+        let mut receiver = kernel.event_bus.subscribe_global();
+
+        // Register an agent first
+        let id = kernel
+            .register_agent("test-agent".to_string(), AgentKind::TerminalChat, None)
+            .await;
+
+        // Clear the registration event
+        let _ = timeout(Duration::from_millis(10), receiver.recv()).await;
+
+        // Subscribe to agent-specific channel to verify cleanup
+        let _agent_receiver = kernel.event_bus.subscribe_agent(&id);
+        assert!(kernel.event_bus.has_agent_channel(&id));
+
+        // Unregister
+        kernel
+            .unregister_agent(&id, "test disconnect".to_string())
+            .await;
+
+        // Verify agent is removed from registry
+        assert!(kernel.registry.get(&id).is_none());
+        assert_eq!(kernel.registry.count(), 0);
+
+        // Verify agent channel is cleaned up
+        assert!(!kernel.event_bus.has_agent_channel(&id));
+
+        // Should receive disconnection event
+        let event = timeout(Duration::from_millis(100), receiver.recv())
+            .await
+            .expect("Should receive event within timeout")
+            .expect("Should receive event");
+
+        assert_eq!(event.source, id);
+        if let EventPayload::AgentDisconnected { reason } = event.payload {
+            assert_eq!(reason, "test disconnect");
+        } else {
+            panic!("Expected AgentDisconnected event");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_uptime_secs_returns_non_negative() {
+        let kernel = PiDaemonKernel::new();
+
+        let uptime = kernel.uptime_secs();
+        assert!(uptime >= 0);
+
+        // Wait a bit and check again
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let uptime2 = kernel.uptime_secs();
+        assert!(uptime2 >= uptime);
+    }
+
+    #[tokio::test]
+    async fn test_init_publishes_startup_event() {
+        let kernel = PiDaemonKernel::new();
+        let mut receiver = kernel.event_bus.subscribe_global();
+
+        kernel.init().await;
+
+        let event = timeout(Duration::from_millis(100), receiver.recv())
+            .await
+            .expect("Should receive event within timeout")
+            .expect("Should receive event");
+
+        assert_eq!(event.source, system_agent_id());
+        if let EventPayload::System { message } = event.payload {
+            assert_eq!(message, "Kernel started");
+        } else {
+            panic!("Expected System event");
+        }
+    }
+
+    #[test]
+    fn test_system_agent_id_is_nil_uuid() {
+        let id = system_agent_id();
+        assert_eq!(id.0, uuid::Uuid::nil());
+    }
+}

--- a/crates/pi-daemon-kernel/src/lib.rs
+++ b/crates/pi-daemon-kernel/src/lib.rs
@@ -1,3 +1,7 @@
 //! Agent kernel — registry, event bus, config, lifecycle management.
 
-// TODO(#5): Add kernel — PiDaemonKernel, AgentRegistry, EventBus
+pub mod event_bus;
+pub mod kernel;
+pub mod registry;
+
+pub use kernel::PiDaemonKernel;

--- a/crates/pi-daemon-kernel/src/registry.rs
+++ b/crates/pi-daemon-kernel/src/registry.rs
@@ -1,0 +1,224 @@
+use chrono::Utc;
+use dashmap::DashMap;
+use pi_daemon_types::agent::{AgentEntry, AgentId, AgentKind, AgentStatus};
+use pi_daemon_types::error::{DaemonError, DaemonResult};
+use tracing::info;
+
+/// Concurrent agent registry. Thread-safe via DashMap.
+pub struct AgentRegistry {
+    agents: DashMap<AgentId, AgentEntry>,
+}
+
+impl AgentRegistry {
+    pub fn new() -> Self {
+        Self {
+            agents: DashMap::new(),
+        }
+    }
+
+    /// Register a new agent. Returns the assigned AgentId.
+    pub fn register(&self, name: String, kind: AgentKind, model: Option<String>) -> AgentId {
+        let id = AgentId::new();
+        let now = Utc::now();
+        let entry = AgentEntry {
+            id: id.clone(),
+            name: name.clone(),
+            kind,
+            status: AgentStatus::Idle,
+            registered_at: now,
+            last_heartbeat: now,
+            model,
+            current_session: None,
+        };
+        self.agents.insert(id.clone(), entry);
+        info!(agent_id = %id, name = %name, "Agent registered");
+        id
+    }
+
+    /// Unregister an agent.
+    pub fn unregister(&self, id: &AgentId) -> DaemonResult<()> {
+        self.agents
+            .remove(id)
+            .map(|_| {
+                info!(agent_id = %id, "Agent unregistered");
+            })
+            .ok_or_else(|| DaemonError::AgentNotFound(id.to_string()))
+    }
+
+    /// Get a clone of an agent entry.
+    pub fn get(&self, id: &AgentId) -> Option<AgentEntry> {
+        self.agents.get(id).map(|entry| entry.clone())
+    }
+
+    /// List all registered agents.
+    pub fn list(&self) -> Vec<AgentEntry> {
+        self.agents
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect()
+    }
+
+    /// Update agent status.
+    pub fn set_status(&self, id: &AgentId, status: AgentStatus) -> DaemonResult<()> {
+        self.agents
+            .get_mut(id)
+            .map(|mut entry| {
+                entry.status = status;
+            })
+            .ok_or_else(|| DaemonError::AgentNotFound(id.to_string()))
+    }
+
+    /// Record a heartbeat from an agent.
+    pub fn heartbeat(&self, id: &AgentId) -> DaemonResult<()> {
+        self.agents
+            .get_mut(id)
+            .map(|mut entry| {
+                entry.last_heartbeat = Utc::now();
+            })
+            .ok_or_else(|| DaemonError::AgentNotFound(id.to_string()))
+    }
+
+    /// Get the number of registered agents.
+    pub fn count(&self) -> usize {
+        self.agents.len()
+    }
+
+    /// Find an agent by name.
+    pub fn find_by_name(&self, name: &str) -> Option<AgentEntry> {
+        self.agents
+            .iter()
+            .find(|entry| entry.value().name == name)
+            .map(|entry| entry.value().clone())
+    }
+}
+
+impl Default for AgentRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pi_daemon_types::agent::AgentKind;
+
+    #[test]
+    fn test_register_agent_appears_in_list() {
+        let registry = AgentRegistry::new();
+        let id = registry.register(
+            "test-agent".to_string(),
+            AgentKind::WebChat,
+            Some("claude-sonnet-4".to_string()),
+        );
+
+        let agents = registry.list();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].id, id);
+        assert_eq!(agents[0].name, "test-agent");
+        assert_eq!(agents[0].kind, AgentKind::WebChat);
+        assert_eq!(agents[0].model, Some("claude-sonnet-4".to_string()));
+        assert_eq!(agents[0].status, AgentStatus::Idle);
+    }
+
+    #[test]
+    fn test_register_then_unregister() {
+        let registry = AgentRegistry::new();
+        let id = registry.register("test".to_string(), AgentKind::PiInstance, None);
+
+        // Verify it exists
+        assert_eq!(registry.count(), 1);
+        assert!(registry.get(&id).is_some());
+
+        // Unregister
+        let result = registry.unregister(&id);
+        assert!(result.is_ok());
+
+        // Verify it's gone
+        assert_eq!(registry.count(), 0);
+        assert!(registry.get(&id).is_none());
+    }
+
+    #[test]
+    fn test_find_by_name() {
+        let registry = AgentRegistry::new();
+        let id1 = registry.register("alice".to_string(), AgentKind::WebChat, None);
+        let _id2 = registry.register("bob".to_string(), AgentKind::PiInstance, None);
+
+        let alice = registry.find_by_name("alice");
+        assert!(alice.is_some());
+        assert_eq!(alice.unwrap().id, id1);
+
+        let charlie = registry.find_by_name("charlie");
+        assert!(charlie.is_none());
+    }
+
+    #[test]
+    fn test_heartbeat_updates_timestamp() {
+        let registry = AgentRegistry::new();
+        let id = registry.register("test".to_string(), AgentKind::TerminalChat, None);
+
+        let original_time = registry.get(&id).unwrap().last_heartbeat;
+
+        // Wait a tiny bit to ensure timestamp difference
+        std::thread::sleep(std::time::Duration::from_millis(1));
+
+        let result = registry.heartbeat(&id);
+        assert!(result.is_ok());
+
+        let updated_time = registry.get(&id).unwrap().last_heartbeat;
+        assert!(updated_time > original_time);
+    }
+
+    #[test]
+    fn test_set_status_changes_status() {
+        let registry = AgentRegistry::new();
+        let id = registry.register("test".to_string(), AgentKind::Hand, None);
+
+        // Initially idle
+        assert_eq!(registry.get(&id).unwrap().status, AgentStatus::Idle);
+
+        // Change to active
+        let result = registry.set_status(&id, AgentStatus::Active);
+        assert!(result.is_ok());
+        assert_eq!(registry.get(&id).unwrap().status, AgentStatus::Active);
+
+        // Change to error
+        let result = registry.set_status(&id, AgentStatus::Error("test error".to_string()));
+        assert!(result.is_ok());
+        assert_eq!(
+            registry.get(&id).unwrap().status,
+            AgentStatus::Error("test error".to_string())
+        );
+    }
+
+    #[test]
+    fn test_unregister_nonexistent_returns_error() {
+        let registry = AgentRegistry::new();
+        let fake_id = AgentId::new();
+
+        let result = registry.unregister(&fake_id);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), DaemonError::AgentNotFound(_)));
+    }
+
+    #[test]
+    fn test_heartbeat_nonexistent_returns_error() {
+        let registry = AgentRegistry::new();
+        let fake_id = AgentId::new();
+
+        let result = registry.heartbeat(&fake_id);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), DaemonError::AgentNotFound(_)));
+    }
+
+    #[test]
+    fn test_set_status_nonexistent_returns_error() {
+        let registry = AgentRegistry::new();
+        let fake_id = AgentId::new();
+
+        let result = registry.set_status(&fake_id, AgentStatus::Active);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), DaemonError::AgentNotFound(_)));
+    }
+}

--- a/crates/pi-daemon-kernel/tests/kernel_lifecycle.rs
+++ b/crates/pi-daemon-kernel/tests/kernel_lifecycle.rs
@@ -1,0 +1,180 @@
+//! Integration test: kernel lifecycle with agent registration and event history
+
+use pi_daemon_kernel::PiDaemonKernel;
+use pi_daemon_types::agent::AgentKind;
+use pi_daemon_types::event::EventPayload;
+use tokio::time::{timeout, Duration};
+
+#[tokio::test]
+async fn test_kernel_lifecycle_with_agent_and_events() {
+    let kernel = PiDaemonKernel::new();
+    let mut receiver = kernel.event_bus.subscribe_global();
+
+    // Initialize kernel
+    kernel.init().await;
+
+    // Should receive startup event
+    let startup_event = timeout(Duration::from_millis(100), receiver.recv())
+        .await
+        .expect("Should receive startup event")
+        .expect("Should receive startup event");
+
+    if let EventPayload::System { message } = startup_event.payload {
+        assert_eq!(message, "Kernel started");
+    } else {
+        panic!("Expected System startup event");
+    }
+
+    // Register an agent
+    let agent_id = kernel
+        .register_agent(
+            "test-lifecycle-agent".to_string(),
+            AgentKind::WebChat,
+            Some("test-model".to_string()),
+        )
+        .await;
+
+    // Should receive registration event
+    let reg_event = timeout(Duration::from_millis(100), receiver.recv())
+        .await
+        .expect("Should receive registration event")
+        .expect("Should receive registration event");
+
+    assert_eq!(reg_event.source, agent_id);
+    if let EventPayload::AgentRegistered { name } = reg_event.payload {
+        assert_eq!(name, "test-lifecycle-agent");
+    } else {
+        panic!("Expected AgentRegistered event");
+    }
+
+    // Verify agent is in registry
+    let agent = kernel.registry.get(&agent_id).unwrap();
+    assert_eq!(agent.name, "test-lifecycle-agent");
+    assert_eq!(agent.kind, AgentKind::WebChat);
+    assert_eq!(agent.model, Some("test-model".to_string()));
+
+    // Unregister the agent
+    kernel
+        .unregister_agent(&agent_id, "lifecycle test complete".to_string())
+        .await;
+
+    // Should receive disconnection event
+    let disc_event = timeout(Duration::from_millis(100), receiver.recv())
+        .await
+        .expect("Should receive disconnection event")
+        .expect("Should receive disconnection event");
+
+    assert_eq!(disc_event.source, agent_id);
+    if let EventPayload::AgentDisconnected { reason } = disc_event.payload {
+        assert_eq!(reason, "lifecycle test complete");
+    } else {
+        panic!("Expected AgentDisconnected event");
+    }
+
+    // Verify agent is removed from registry
+    assert!(kernel.registry.get(&agent_id).is_none());
+
+    // Verify event history contains our events
+    let history = kernel.event_bus.history(10).await;
+    assert_eq!(history.len(), 3); // startup + register + unregister
+
+    // Events should be in reverse chronological order
+    if let EventPayload::AgentDisconnected { .. } = history[0].payload {
+        // Most recent event should be disconnection
+    } else {
+        panic!("Expected most recent event to be AgentDisconnected");
+    }
+
+    if let EventPayload::System { message } = &history[2].payload {
+        // Oldest event should be startup
+        assert_eq!(message, "Kernel started");
+    } else {
+        panic!("Expected oldest event to be System startup");
+    }
+}
+
+#[tokio::test]
+async fn test_multiple_agents_lifecycle() {
+    let kernel = PiDaemonKernel::new();
+    kernel.init().await;
+
+    // Register multiple agents
+    let agent1 = kernel
+        .register_agent("agent-1".to_string(), AgentKind::PiInstance, None)
+        .await;
+
+    let agent2 = kernel
+        .register_agent(
+            "agent-2".to_string(),
+            AgentKind::TerminalChat,
+            Some("claude-haiku".to_string()),
+        )
+        .await;
+
+    // Verify both are registered
+    assert_eq!(kernel.registry.count(), 2);
+    let agents = kernel.registry.list();
+    assert_eq!(agents.len(), 2);
+
+    // Verify we can find by name
+    let found1 = kernel.registry.find_by_name("agent-1");
+    assert!(found1.is_some());
+    assert_eq!(found1.unwrap().id, agent1);
+
+    let found2 = kernel.registry.find_by_name("agent-2");
+    assert!(found2.is_some());
+    assert_eq!(found2.unwrap().id, agent2);
+
+    // Unregister first agent
+    kernel
+        .unregister_agent(&agent1, "test complete".to_string())
+        .await;
+
+    // Second agent should still be there
+    assert_eq!(kernel.registry.count(), 1);
+    assert!(kernel.registry.get(&agent1).is_none());
+    assert!(kernel.registry.get(&agent2).is_some());
+
+    // Unregister second agent
+    kernel
+        .unregister_agent(&agent2, "all done".to_string())
+        .await;
+
+    // No agents left
+    assert_eq!(kernel.registry.count(), 0);
+}
+
+#[tokio::test]
+async fn test_event_history_persistence() {
+    let kernel = PiDaemonKernel::new();
+    kernel.init().await;
+
+    // Generate several events
+    for i in 0..5 {
+        kernel
+            .register_agent(format!("agent-{}", i), AgentKind::Hand, None)
+            .await;
+    }
+
+    // All agents should be registered
+    assert_eq!(kernel.registry.count(), 5);
+
+    // History should contain startup + 5 registration events = 6 total
+    let history = kernel.event_bus.history(20).await;
+    assert_eq!(history.len(), 6);
+
+    // Verify event types in history
+    let mut system_events = 0;
+    let mut registration_events = 0;
+
+    for event in history {
+        match event.payload {
+            EventPayload::System { .. } => system_events += 1,
+            EventPayload::AgentRegistered { .. } => registration_events += 1,
+            _ => panic!("Unexpected event type in history"),
+        }
+    }
+
+    assert_eq!(system_events, 1); // startup event
+    assert_eq!(registration_events, 5); // 5 agent registrations
+}

--- a/crates/pi-daemon-kernel/tests/registry_concurrent.rs
+++ b/crates/pi-daemon-kernel/tests/registry_concurrent.rs
@@ -1,0 +1,196 @@
+//! Integration test: concurrent agent registration stress test
+
+use pi_daemon_kernel::registry::AgentRegistry;
+use pi_daemon_types::agent::{AgentKind, AgentStatus};
+use std::sync::Arc;
+use tokio::task::JoinSet;
+
+#[tokio::test]
+async fn test_concurrent_agent_registration() {
+    let registry = Arc::new(AgentRegistry::new());
+    let mut tasks = JoinSet::new();
+
+    // Spawn 10 concurrent tasks, each registering agents
+    for task_id in 0..10 {
+        let registry_clone = registry.clone();
+        tasks.spawn(async move {
+            let mut agent_ids = Vec::new();
+
+            // Each task registers 5 agents
+            for i in 0..5 {
+                let agent_name = format!("task-{}-agent-{}", task_id, i);
+                let id = registry_clone.register(
+                    agent_name,
+                    AgentKind::WebChat,
+                    Some("test-model".to_string()),
+                );
+                agent_ids.push(id);
+            }
+
+            agent_ids
+        });
+    }
+
+    // Collect all agent IDs from all tasks
+    let mut all_agent_ids = Vec::new();
+    while let Some(result) = tasks.join_next().await {
+        let task_agent_ids = result.expect("Task should complete successfully");
+        all_agent_ids.extend(task_agent_ids);
+    }
+
+    // Should have 50 total agents (10 tasks × 5 agents)
+    assert_eq!(all_agent_ids.len(), 50);
+    assert_eq!(registry.count(), 50);
+
+    // All agent IDs should be unique
+    let mut unique_ids = all_agent_ids.clone();
+    unique_ids.sort_by_key(|id| id.0);
+    unique_ids.dedup();
+    assert_eq!(unique_ids.len(), 50, "All agent IDs should be unique");
+
+    // All agents should be findable in registry
+    for agent_id in &all_agent_ids {
+        let agent = registry.get(agent_id);
+        assert!(agent.is_some(), "Agent {} should be in registry", agent_id);
+
+        let agent = agent.unwrap();
+        assert_eq!(agent.kind, AgentKind::WebChat);
+        assert_eq!(agent.status, AgentStatus::Idle);
+        assert!(agent.name.starts_with("task-"));
+    }
+
+    // List should return all agents
+    let listed_agents = registry.list();
+    assert_eq!(listed_agents.len(), 50);
+}
+
+#[tokio::test]
+async fn test_concurrent_agent_operations() {
+    let registry = Arc::new(AgentRegistry::new());
+
+    // Pre-register 20 agents
+    let mut agent_ids = Vec::new();
+    for i in 0..20 {
+        let id = registry.register(format!("agent-{}", i), AgentKind::PiInstance, None);
+        agent_ids.push(id);
+    }
+
+    let mut tasks = JoinSet::new();
+
+    // Spawn concurrent operations
+    for i in 0..10 {
+        let registry_clone = registry.clone();
+        let agent_id = agent_ids[i % agent_ids.len()].clone();
+
+        match i % 4 {
+            0 => {
+                // Heartbeat task
+                tasks.spawn(async move {
+                    for _ in 0..5 {
+                        let _ = registry_clone.heartbeat(&agent_id);
+                        tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+                    }
+                });
+            }
+            1 => {
+                // Status update task
+                tasks.spawn(async move {
+                    let _ = registry_clone.set_status(&agent_id, AgentStatus::Active);
+                    tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+                    let _ = registry_clone.set_status(&agent_id, AgentStatus::Idle);
+                });
+            }
+            2 => {
+                // Read task
+                tasks.spawn(async move {
+                    for _ in 0..10 {
+                        let _ = registry_clone.get(&agent_id);
+                        let _ = registry_clone.list();
+                        tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+                    }
+                });
+            }
+            3 => {
+                // Find by name task
+                tasks.spawn(async move {
+                    let agent_name = format!("agent-{}", i % 20);
+                    for _ in 0..5 {
+                        let _ = registry_clone.find_by_name(&agent_name);
+                        tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+                    }
+                });
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    // Wait for all tasks to complete
+    while let Some(result) = tasks.join_next().await {
+        result.expect("All tasks should complete successfully");
+    }
+
+    // Registry should still be in a consistent state
+    assert_eq!(registry.count(), 20);
+
+    // All original agents should still exist
+    for agent_id in &agent_ids {
+        let agent = registry.get(agent_id);
+        assert!(
+            agent.is_some(),
+            "Agent should still exist after concurrent operations"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_concurrent_register_unregister() {
+    let registry = Arc::new(AgentRegistry::new());
+    let mut tasks = JoinSet::new();
+
+    // Spawn tasks that register and then unregister agents
+    for task_id in 0..5 {
+        let registry_clone = registry.clone();
+        tasks.spawn(async move {
+            let mut registered_ids = Vec::new();
+
+            // Register 3 agents
+            for i in 0..3 {
+                let id = registry_clone.register(
+                    format!("temp-task-{}-agent-{}", task_id, i),
+                    AgentKind::Hand,
+                    None,
+                );
+                registered_ids.push(id);
+            }
+
+            // Small delay
+            tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
+
+            // Unregister 2 of the 3 agents
+            for id in registered_ids.iter().take(2) {
+                let _ = registry_clone.unregister(id);
+            }
+
+            // Return the ID of the remaining agent
+            registered_ids[2].clone()
+        });
+    }
+
+    // Collect remaining agent IDs
+    let mut remaining_ids = Vec::new();
+    while let Some(result) = tasks.join_next().await {
+        let remaining_id = result.expect("Task should complete");
+        remaining_ids.push(remaining_id);
+    }
+
+    // Should have 5 remaining agents (1 per task)
+    assert_eq!(registry.count(), 5);
+    assert_eq!(remaining_ids.len(), 5);
+
+    // Verify the remaining agents are the correct ones
+    for id in &remaining_ids {
+        let agent = registry.get(id);
+        assert!(agent.is_some());
+        assert!(agent.unwrap().name.contains("agent-2")); // The third agent (index 2)
+    }
+}

--- a/crates/pi-daemon-types/src/event.rs
+++ b/crates/pi-daemon-types/src/event.rs
@@ -14,6 +14,12 @@ impl EventId {
     }
 }
 
+impl std::fmt::Display for EventId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl Default for EventId {
     fn default() -> Self {
         Self::new()


### PR DESCRIPTION
## Summary
Implements the core pi-daemon kernel with concurrent agent registry and pub/sub event bus, providing the foundation for all higher-level subsystems.

## Changes
- **AgentRegistry**: DashMap-based concurrent agent tracking with register/unregister/heartbeat/status operations
- **EventBus**: tokio broadcast channels supporting both global broadcast and per-agent targeted events
- **PiDaemonKernel**: Main coordinator composing registry + event bus with uptime tracking and lifecycle management
- **Event History**: Ring buffer storing last 1000 events with LRU eviction for debugging/monitoring
- **Integration Tests**: Comprehensive lifecycle and concurrency stress testing
- **Display Trait**: Added Display implementation for EventId to support tracing

## Architecture Features
- ✅ **Fully Concurrent**: DashMap eliminates Mutex contention for high-performance agent operations
- ✅ **Flexible Event Routing**: Supports both broadcast-to-all and targeted-to-agent event delivery
- ✅ **Event History**: 1000-event ring buffer with newest-first ordering for operational visibility  
- ✅ **Type Safety**: Full integration with pi-daemon-types for AgentId, Event, Error handling
- ✅ **Async/Await**: All public APIs are async-ready for integration with API server

## Testing  
- ✅ **60 Total Tests**: All existing + 26 new kernel tests pass
- ✅ **Unit Tests**: Registry operations, event bus pub/sub, kernel lifecycle
- ✅ **Integration Tests**: Full kernel lifecycle with agent registration and event tracking
- ✅ **Concurrency Tests**: 10 concurrent tasks × 5 agents each = 50 parallel registrations  
- ✅ **Stress Tests**: Mixed concurrent operations (heartbeat, status, read, find-by-name)
- ✅ **Zero Clippy Warnings**: Clean, idiomatic Rust code

## Key APIs
```rust
// Agent management
let id = kernel.register_agent(name, kind, model).await;
kernel.unregister_agent(&id, reason).await;

// Event pub/sub  
kernel.event_bus.publish(event).await;
let receiver = kernel.event_bus.subscribe_global();
let history = kernel.event_bus.history(limit).await;

// Registry operations
let agent = kernel.registry.get(&id);
let agents = kernel.registry.list();
kernel.registry.heartbeat(&id)?;
```

Ready for API server integration in issue #7.

Closes #5