### PR TITLE
fix: add workflow_run triggers to Check Gate (#67)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -5,14 +5,30 @@ name: "Check Gate"
 # and approves when every check reaches a terminal state (pass/skip).
 #
 # Triggers:
-#   1. check_suite:completed — fires each time a workflow finishes
-#   2. workflow_dispatch      — manual re-trigger escape hatch
+#   1. workflow_run:completed — fires when a named Actions workflow finishes
+#   2. check_suite:completed — fires for external app checks (Codecov, etc.)
+#   3. workflow_dispatch      — manual re-trigger escape hatch
 #
 # NOTE: GitHub always runs workflow files from the DEFAULT BRANCH (main),
 # not from the PR branch. Changes here won't take effect until merged.
 
 on:
+  # check_suite:completed does NOT fire for GitHub Actions check suites
+  # (only for external apps like Codecov). We keep it for future external
+  # integrations but workflow_run is the real trigger for Actions workflows.
   check_suite:
+    types: [completed]
+  # workflow_run fires when a named workflow completes. This is the only
+  # way to trigger on Actions workflow completions. Workflow names change
+  # rarely (6 workflows) vs check/job names (32+), so this is acceptable.
+  workflow_run:
+    workflows:
+      - "CI"
+      - "Security"
+      - "Commit Message Secret Scan"
+      - "PR Hygiene"
+      - "Documentation"
+      - "Architectural Review"
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -33,9 +49,10 @@ jobs:
     # Run for PRs or manual dispatch
     if: >-
       (github.event_name == 'workflow_dispatch') ||
-      (github.event.check_suite.pull_requests[0] != null)
+      (github.event.check_suite.pull_requests[0] != null) ||
+      (github.event.workflow_run.pull_requests[0] != null)
     concurrency:
-      group: check-gate-${{ github.event.inputs.pr_number || github.event.check_suite.pull_requests[0].number }}
+      group: check-gate-${{ github.event.inputs.pr_number || github.event.check_suite.pull_requests[0].number || github.event.workflow_run.pull_requests[0].number || 'unknown' }}
       cancel-in-progress: false
     steps:
       - name: Evaluate PR checks
@@ -53,6 +70,9 @@ jobs:
               core.info(`🔧 Manual dispatch for PR #${prNumber}`);
             } else if (context.payload.check_suite) {
               const prs = context.payload.check_suite.pull_requests;
+              if (prs && prs.length > 0) prNumber = prs[0].number;
+            } else if (context.payload.workflow_run) {
+              const prs = context.payload.workflow_run.pull_requests;
               if (prs && prs.length > 0) prNumber = prs[0].number;
             }
             if (!prNumber) {
@@ -73,11 +93,18 @@ jobs:
             core.info(`Head SHA: ${sha}`);
 
             // ── 3. Fetch ALL check runs (paginated) ───────────────
-            const allRuns = await github.paginate(
-              github.rest.checks.listForRef,
-              { owner, repo, ref: sha, per_page: 100 },
-              (resp) => resp.data.check_runs
-            );
+            // github.paginate doesn't handle nested arrays (check_runs)
+            // correctly, so we paginate manually.
+            let allRuns = [];
+            let page = 1;
+            while (true) {
+              const { data } = await github.rest.checks.listForRef({
+                owner, repo, ref: sha, per_page: 100, page,
+              });
+              allRuns = allRuns.concat(data.check_runs);
+              if (allRuns.length >= data.total_count) break;
+              page++;
+            }
             core.info(`Found ${allRuns.length} total check runs`);
 
             // ── 4. Filter out our own check run ───────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive CI/CD pipeline with 25+ automated checks (#24)
 - Supply chain security checks with cargo-deny (#34)
 - Code quality checks: unsafe detection, TODO tracking, docs drift, binary size (#35)
-- Auto-approve workflow for seamless PR merging (#56/#57)
+- Dynamic Check Gate system — discovers all PR checks automatically, no hardcoded names (#63/#65)
+- Manual re-trigger for Check Gate via `workflow_dispatch` (#60/#61)
 
 ### Infrastructure
 - Workspace-based Rust project structure with 5 crates

--- a/docs/PR-Reviews.md
+++ b/docs/PR-Reviews.md
@@ -162,19 +162,43 @@ The most unique check. Uses **Gemini 2.5 Flash** via OpenRouter to review every 
 
 ---
 
-## Branch Protection & Auto-Approve
+## Branch Protection & Check Gate
 
 The `main` branch is protected with the following rules:
 
 - **Require a pull request** — no direct pushes to `main`
-- **Require 1 approving review** — satisfied by the auto-approve bot (see below)
+- **Require 1 approving review** — satisfied by the Check Gate bot (see below)
 - **Require status checks to pass** — security scans and commit-message scan must pass
 - **No force-push** — prevents history rewriting on `main`
 - **No deletions** — prevents accidental branch deletion
 
-### Auto-Approve Workflow
+### Check Gate (`auto-approve.yml`)
 
-The `auto-approve.yml` workflow acts as the required reviewer. When all CI checks on a PR complete successfully, it automatically submits an approving review as `github-actions[bot]`. This allows agent-opened PRs to merge without human intervention while still enforcing that every check passes.
+The Check Gate is a **dynamic auto-approve system** that discovers and tracks all PR checks automatically — no hardcoded check names.
+
+**How it works:**
+
+1. Each time a CI workflow completes (`workflow_run` event), the Gate fires
+2. It fetches **all** check runs for the PR head SHA using the paginated Checks API (`github.paginate`)
+3. It self-excludes its own `Check Gate` check run to prevent loops
+4. It classifies every check: pass, fail, skip, running, pending, cancelled
+5. **Decision:**
+   - Any still running/pending → wait (exit, will re-trigger on next workflow completion)
+   - Any failed/cancelled → deny (log details, do not approve)
+   - All terminal + none failed + ≥20 checks present → approve with summary
+6. If approved, submits an approving review as `github-actions[bot]`
+
+**Key properties:**
+- **Zero hardcoded check names** — discovers checks dynamically
+- **Minimum threshold (20)** — prevents premature approval when few checks have registered; this is the only tunable
+- **Concurrency groups** — prevents race conditions from simultaneous triggers
+- **Manual re-trigger** — escape hatch when event-driven triggers fail:
+
+```bash
+gh workflow run auto-approve.yml -f pr_number=66
+```
+
+**Adding new CI checks:** Just add them to any workflow file. The Gate discovers them automatically. No changes to `auto-approve.yml` needed.
 
 If any check fails, the bot does not approve and the PR cannot be merged.
 


### PR DESCRIPTION
## Fixes #67

### Problem

The Check Gate (#65) removed `workflow_run` triggers and relied solely on `check_suite: completed`. But GitHub's docs state:

> check suites that are created automatically by GitHub Actions don't trigger this event.

Since all CI is GitHub Actions, the Gate never fired. PR #66 has all 32 checks passing with 0 reviews.

### Fix

- Add `workflow_run` triggers for all 6 workflows (CI, Security, Commit Message Secret Scan, PR Hygiene, Documentation, Architectural Review)
- Update job condition and PR number resolution for `workflow_run` events
- Fix concurrency group expression to handle all 3 event types
- Keep `check_suite` for future external integrations (Codecov, etc.)

### Trade-off

`workflow_run` requires explicit workflow names — this is a GitHub limitation and cannot be avoided. However, **workflow names change rarely** (6 total) vs check/job names (32+). The entire check evaluation logic remains fully dynamic with zero hardcoded check names.