### PR TITLE
fix: make Docs Drift and Changelog checks blocking, expand coverage (#69)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,12 +302,13 @@ jobs:
       - name: Check for docs drift
         run: |
           CHANGED=$(git diff origin/main...HEAD --name-only)
+          ERRORS=""
           WARNINGS=""
           
           # routes changed → API-Reference.md should too
           if echo "$CHANGED" | grep -q 'routes'; then
             if ! echo "$CHANGED" | grep -q 'API-Reference.md'; then
-              WARNINGS="${WARNINGS}\n⚠️ Route files changed but docs/API-Reference.md was not updated"
+              ERRORS="${ERRORS}\n❌ Route files changed but docs/API-Reference.md was not updated"
             fi
           fi
           
@@ -315,7 +316,7 @@ jobs:
           if echo "$CHANGED" | grep -q 'Cargo.toml'; then
             if git diff origin/main...HEAD -- Cargo.toml | grep -q 'members'; then
               if ! echo "$CHANGED" | grep -q 'Architecture.md'; then
-                WARNINGS="${WARNINGS}\n⚠️ Cargo.toml workspace members changed but docs/Architecture.md was not updated"
+                ERRORS="${ERRORS}\n❌ Cargo.toml workspace members changed but docs/Architecture.md was not updated"
               fi
             fi
           fi
@@ -323,12 +324,34 @@ jobs:
           # Config types changed → Configuration.md should too
           if echo "$CHANGED" | grep -q 'config\.rs'; then
             if ! echo "$CHANGED" | grep -q 'Configuration.md'; then
-              WARNINGS="${WARNINGS}\n⚠️ Config code changed but docs/Configuration.md was not updated"
+              ERRORS="${ERRORS}\n❌ Config code changed but docs/Configuration.md was not updated"
+            fi
+          fi
+
+          # Workflow files changed → PR-Reviews.md should too
+          if echo "$CHANGED" | grep -q '\.github/workflows/'; then
+            if ! echo "$CHANGED" | grep -q 'PR-Reviews.md'; then
+              ERRORS="${ERRORS}\n❌ Workflow files changed but docs/PR-Reviews.md was not updated"
+            fi
+          fi
+
+          # deny.toml changed → PR-Reviews.md supply chain section should too
+          if echo "$CHANGED" | grep -q 'deny\.toml'; then
+            if ! echo "$CHANGED" | grep -qE 'PR-Reviews.md|Architecture.md'; then
+              WARNINGS="${WARNINGS}\n⚠️ deny.toml changed but related docs were not updated"
             fi
           fi
           
-          if [ -n "$WARNINGS" ]; then
-            echo "::warning::Potential documentation drift:${WARNINGS}"
+          if [ -n "$ERRORS" ]; then
+            echo -e "Documentation drift detected:${ERRORS}"
+            if [ -n "$WARNINGS" ]; then
+              echo -e "\nAdditional warnings:${WARNINGS}"
+            fi
+            echo "::error::Documentation drift detected — update the relevant docs/ files"
+            exit 1
+          elif [ -n "$WARNINGS" ]; then
+            echo -e "Documentation drift warnings:${WARNINGS}"
+            echo "::warning::Potential documentation drift (advisory)"
           else
             echo "✅ No documentation drift detected"
           fi
@@ -344,11 +367,22 @@ jobs:
       - name: Check changelog updated
         run: |
           CHANGED=$(git diff origin/main...HEAD --name-only)
-          HAS_RS=$(echo "$CHANGED" | grep '\.rs$' || true)
           HAS_CHANGELOG=$(echo "$CHANGED" | grep 'CHANGELOG.md' || true)
           
-          if [ -n "$HAS_RS" ] && [ -z "$HAS_CHANGELOG" ]; then
-            echo "::warning::Rust source files changed but CHANGELOG.md was not updated"
+          # Meaningful changes that warrant a changelog entry
+          HAS_RS=$(echo "$CHANGED" | grep '\.rs$' || true)
+          HAS_WORKFLOWS=$(echo "$CHANGED" | grep '\.github/workflows/' || true)
+          HAS_CARGO=$(echo "$CHANGED" | grep 'Cargo\.toml' || true)
+          
+          HAS_MEANINGFUL=""
+          [ -n "$HAS_RS" ] && HAS_MEANINGFUL="Rust source files"
+          [ -n "$HAS_WORKFLOWS" ] && HAS_MEANINGFUL="${HAS_MEANINGFUL:+$HAS_MEANINGFUL, }workflow files"
+          [ -n "$HAS_CARGO" ] && HAS_MEANINGFUL="${HAS_MEANINGFUL:+$HAS_MEANINGFUL, }Cargo.toml"
+          
+          if [ -n "$HAS_MEANINGFUL" ] && [ -z "$HAS_CHANGELOG" ]; then
+            echo "Changed: $HAS_MEANINGFUL"
+            echo "::error::$HAS_MEANINGFUL changed but CHANGELOG.md was not updated"
+            exit 1
           else
             echo "✅ Changelog check passed"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dynamic Check Gate system — discovers all PR checks automatically, no hardcoded names (#63/#65)
 - Manual re-trigger for Check Gate via `workflow_dispatch` (#60/#61)
 
+### Fixed
+- Docs Drift check now covers workflow file changes and fails instead of only warning (#69)
+- Changelog check now covers workflow and Cargo.toml changes, not just `.rs` files (#69)
+- Check quality checks use `exit 1` instead of `::warning::` so they actually block PRs (#69)
+
 ### Infrastructure
 - Workspace-based Rust project structure with 5 crates
 - GitHub Actions workflows for security, testing, and quality assurance

--- a/docs/PR-Reviews.md
+++ b/docs/PR-Reviews.md
@@ -74,8 +74,8 @@ Implemented as a **hybrid Documentation Architecture Validator** — a single wo
 | **Crate ↔ Architecture Sync** | Custom script | ⚠️ | ✅ | Parses `Cargo.toml` workspace members, verifies each crate appears in `Architecture.md`. Catches "added a crate but forgot to document it." |
 | **Internal Link Validation** | lychee | ⚠️ | ❌ | Validates all `[[Wiki-Links]]` and `[text](relative/path.md)` links resolve to real files. |
 | **Heading Structure Lint** | markdownlint | ⚠️ | ❌ | Consistent heading hierarchy: every page starts with `# Title`, uses `##` for sections, no level skipping. Config: `.markdownlint.json`. |
-| **Docs Drift Detection** | Custom script | ⚠️ | ✅ | If `routes*.rs` changed, was `API-Reference.md` updated? If `Cargo.toml` members changed, was `Architecture.md` updated? |
-| **Changelog Enforcement** | Custom script | ⚠️ | ❌ | Warns if `*.rs` files changed but `CHANGELOG.md` wasn't updated. |
+| **Docs Drift Detection** | Custom script | ✅ | ✅ | Fails if routes → `API-Reference.md`, `Cargo.toml` members → `Architecture.md`, `config.rs` → `Configuration.md`, or workflow files → `PR-Reviews.md` are changed without updating the corresponding docs. |
+| **Changelog Enforcement** | Custom script | ✅ | ❌ | Fails if `.rs`, workflow (`.yml`), or `Cargo.toml` files changed but `CHANGELOG.md` wasn't updated. |
 | **Broken External Links** | lychee | ⚠️ | ❌ | Checks external URLs in markdown files for 404s. |
 
 #### Semantic Checks (LLM-Based — Only When `docs/` Modified)


### PR DESCRIPTION
## Fixes #69

### Problem

The Docs Drift and Changelog checks always passed — even when docs were clearly stale. Two issues:

1. **Advisory only** — Both used `::warning::` annotations which are cosmetic. GitHub treats them as `success` conclusion. The Check Gate (or any branch protection) could never block based on these.

2. **Narrow coverage** — Docs Drift only checked 3 file patterns (routes, Cargo.toml members, config.rs). Changelog only triggered on `.rs` files. Workflow changes, Cargo.toml changes, and other significant modifications were invisible.

**Evidence:** PR #65 rewrote the entire auto-approve system (`.github/workflows/auto-approve.yml`) without updating `docs/PR-Reviews.md` or `CHANGELOG.md`. All checks passed with zero warnings.

### Fix

**Docs Drift:**
- Added: workflow files → `PR-Reviews.md` (blocking)
- Added: `deny.toml` → related docs (advisory)
- Changed from `::warning::` to `exit 1` for blocking drift

**Changelog:**
- Expanded trigger scope: `.rs`, `.yml` (workflows), `Cargo.toml`
- Changed from `::warning::` to `exit 1` when changelog missing
- Logs which file types triggered the requirement

**Docs updated:**
- `docs/PR-Reviews.md` — Docs Drift and Changelog rows updated from ⚠️ advisory to ✅ blocking
- `CHANGELOG.md` — entries for Check Gate and this fix