### PR TITLE
test: trigger sandbox integration workflow

### DIFF
--- a/crates/pi-daemon-api/src/routes.rs
+++ b/crates/pi-daemon-api/src/routes.rs
@@ -3,6 +3,7 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
+use chrono::Utc;
 use pi_daemon_types::agent::{AgentId, AgentKind};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -131,7 +132,10 @@ pub async fn get_events(State(state): State<Arc<AppState>>) -> impl IntoResponse
 
 /// GET /api/health — simple health check.
 pub async fn health_check() -> impl IntoResponse {
-    Json(serde_json::json!({"status": "ok"}))
+    Json(serde_json::json!({
+        "status": "ok",
+        "timestamp": Utc::now().to_rfc3339()
+    }))
 }
 
 /// POST /api/shutdown — graceful shutdown.


### PR DESCRIPTION
## Summary
Test the new sandbox integration workflow by making a small change to trigger it.

## Changes  
- Add timestamp to health endpoint response for testing
- Should trigger sandbox test since crates/** changed

## Test Goal
Verify the sandbox integration workflow runs correctly:
- Builds release binary
- Starts actual daemon process  
- Tests all endpoints and functionality
- Validates concurrency, memory, crash recovery
- Performs graceful shutdown

This validates our real deployment testing infrastructure.